### PR TITLE
Compatibility with Gradle version 7 and later.

### DIFF
--- a/src/platforms/android/include.gradle
+++ b/src/platforms/android/include.gradle
@@ -1,5 +1,5 @@
 dependencies {
-  compile 'com.android.support:customtabs:27.0.2'
-  compile 'com.android.support:appcompat-v7:27.0.2'
+  api 'com.android.support:customtabs:27.0.2'
+  api 'com.android.support:appcompat-v7:27.0.2'
   implementation 'androidx.browser:browser:1.2.0'
 }


### PR DESCRIPTION
By switching form compile() to api(), the plugin is made compatible with Gradle 7 and later.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests are passing
- [x] Tests for the changes are included

## What is the current behavior?
The plugin is not compatible with Gradle version 7 or later. See issue https://github.com/alexziskind1/nativescript-oauth2/issues/186

## What is the new behavior?
The plugin is compatible with Gradle version 7 or later.

Closes #186.

